### PR TITLE
Add forgotten end-of-code backticks

### DIFF
--- a/docs/tutorials/tutorial-quick-start.md
+++ b/docs/tutorials/tutorial-quick-start.md
@@ -230,6 +230,7 @@ SCIF_APPBIN_hello_world_echo=/scif/apps/hello-world-echo/bin
 SCIF_MESSAGELEVEL=INFO
 exit
 ...
+```
 
 After exiting, we can do the same in the context of a specific app:
 


### PR DESCRIPTION
Documentation got messed up by code as text and text as code.