### PR TITLE
Fix parsing of additional arguments to run

### DIFF
--- a/scif/client/__init__.py
+++ b/scif/client/__init__.py
@@ -120,9 +120,8 @@ def get_parser():
                                  help="entrypoint to run a scientific filesystem")
 
 
-    run.add_argument("app", nargs='?',
-                     # Question: should SCIF have a default runscript?
-                     help="app to target for the entry, defaults to shell if not set.", 
+    run.add_argument("cmd", nargs='*',
+                     help="app and optional arguments to target for the entry", 
                      type=str)
 
 

--- a/scif/client/__init__.py
+++ b/scif/client/__init__.py
@@ -121,9 +121,9 @@ def get_parser():
 
 
     run.add_argument("app", nargs='?',
+                     # Question: should SCIF have a default runscript?
                      help="app to target for the entry, defaults to shell if not set.", 
                      type=str)
-
 
 
     # List and dump

--- a/scif/client/run.py
+++ b/scif/client/run.py
@@ -26,21 +26,19 @@ import os
 def main(args,parser,subparser):
 
     from scif.main import ScifRecipe
-    cmd = args.app
+    cmd = args.cmd
     client = ScifRecipe(quiet=True, writable=args.writable)
 
-    # If command is set to an app (or more), otherwise we default to /bin/bash
-    app = None
-    if cmd is not None:
-        if not isinstance(cmd,list):
-            cmd = [cmd]
+    if len(cmd) == 0:
+        bot.warning('You must supply an appname to run.')
+        bot.custom(prefix="Example: ", message="scif run <app>")
+        sys.exit(1)
 
-        # The app is the first argument 
-        app = cmd.pop(0)
+    app = cmd.pop(0)
 
-        # Additional commands to pass into run, or set to None
-        if len(cmd) == 0:
-            cmd = None
+    # Remaining arguments indicate options/args to pass on
+    if len(cmd) == 0:
+        cmd = None
 
     client = ScifRecipe(quiet=True, writable=args.writable)
     client.run(app, args=cmd)

--- a/scif/client/run.py
+++ b/scif/client/run.py
@@ -32,7 +32,7 @@ def main(args,parser,subparser):
     # If command is set to an app (or more), otherwise we default to /bin/bash
     app = None
     if cmd is not None:
-        if not instance(cmd,list):
+        if not isinstance(cmd,list):
             cmd = [cmd]
 
         # The app is the first argument 

--- a/scif/client/run.py
+++ b/scif/client/run.py
@@ -26,6 +26,21 @@ import os
 def main(args,parser,subparser):
 
     from scif.main import ScifRecipe
-    app = args.app
+    cmd = args.app
     client = ScifRecipe(quiet=True, writable=args.writable)
-    client.run(app)
+
+    # If command is set to an app (or more), otherwise we default to /bin/bash
+    app = None
+    if cmd is not None:
+        if not instance(cmd,list):
+            cmd = [cmd]
+
+        # The app is the first argument 
+        app = cmd.pop(0)
+
+        # Additional commands to pass into run, or set to None
+        if len(cmd) == 0:
+            cmd = None
+
+    client = ScifRecipe(quiet=True, writable=args.writable)
+    client.run(app, args=cmd)

--- a/scif/main/apps.py
+++ b/scif/main/apps.py
@@ -47,7 +47,7 @@ def apps(self):
     return apps
 
 
-def activate(self, app, cmd=None):
+def activate(self, app, cmd=None, args=None):
     '''if an app is valid, get it's environment to make it active.
        Update the entrypoint to be relevant to the app runscript.
     
@@ -55,6 +55,8 @@ def activate(self, app, cmd=None):
     ==========
     app: the name of the app to activate
     cmd: if defined, the entry point (command) to run. Otherwise uses apprun
+    args: additional commands for the apprun
+
     '''
     if app is None:
         bot.warning('No app selected, will run default %s' %self._entry_point)    
@@ -77,7 +79,10 @@ def activate(self, app, cmd=None):
         elif 'SCIF_APPRUN' in config:
             if os.path.exists(config['SCIF_APPRUN']):
                 self._entry_point = [SCIF_SHELL, config['SCIF_APPRUN']]
- 
+                if args is not None:
+                    args = parse_entrypoint(args)
+                    self._entry_point += args
+
         # Update the environment for active app (updates ScifRecipe object)
         appenv = self.get_appenv(app, isolated=False, update=True)
 

--- a/scif/main/commands.py
+++ b/scif/main/commands.py
@@ -94,7 +94,7 @@ def execute(self, app, cmd=None):
 
 
 
-def run(self, app=None):
+def run(self, app=None, args=None):
     '''run an app. This means the following:
 
     1. Check that the app is valid for the client. Don't proceed otherwise
@@ -105,12 +105,13 @@ def run(self, app=None):
     Parameters
     ==========
     app: the name of the scif app to run
+    args: a list of one or more additional arguments to pass to runscript
 
     '''
-    self.activate(app)    # checks for existence
-                          # sets _active to app's name
-                          # updates environment
-                          # sets entrypoint
-                          # sets entryfolder
+    self.activate(app, args=args)    # checks for existence
+                                     # sets _active to app's name
+                                     # updates environment
+                                     # sets entrypoint
+                                     # sets entryfolder
 
     return self._exec(app)


### PR DESCRIPTION
Given a run command with additional arguments, they should be passed on. This fix will handle that by treating the run similarly to the exec, except minus the main executable (which is the runscript)