### PR TITLE
Add environment to be sourced (inline with runscript)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versions in parentheses coincide with what is available on [pypi](https://pypi.o
 
 ## [xxx](https://github.com/vsoch/scif/tree/master) (development)
 
+ - updates to source environment correctly (0.0.69)
  - added append sticker (`[append]` for `>>`) (0.0.68)
  - adding scif stamps for pipes [pipe], and in/output direction [out]/[in] (0.0.67)
  - fixing bug that arguments (--) don't get passed through to exec/run (0.0.65)

--- a/scif/main/__init__.py
+++ b/scif/main/__init__.py
@@ -26,7 +26,6 @@ from scif.main.commands import ( run, _exec, execute )
 from scif.main.environment import ( 
     add_env, 
     append_path,
-    expand_env,
     export_env,
     get_env, 
     get_appenv, 
@@ -83,7 +82,6 @@ ScifRecipe.append_path = append_path
 ScifRecipe._init_env = init_env
 ScifRecipe.add_env = add_env
 ScifRecipe.export_env = export_env
-ScifRecipe.expand_env = expand_env
 ScifRecipe.get_env = get_env
 ScifRecipe.load_env = load_env
 ScifRecipe.update_env = update_env

--- a/scif/main/__init__.py
+++ b/scif/main/__init__.py
@@ -26,6 +26,7 @@ from scif.main.commands import ( run, _exec, execute )
 from scif.main.environment import ( 
     add_env, 
     append_path,
+    expand_env,
     export_env,
     get_env, 
     get_appenv, 
@@ -82,6 +83,7 @@ ScifRecipe.append_path = append_path
 ScifRecipe._init_env = init_env
 ScifRecipe.add_env = add_env
 ScifRecipe.export_env = export_env
+ScifRecipe.expand_env = expand_env
 ScifRecipe.get_env = get_env
 ScifRecipe.load_env = load_env
 ScifRecipe.update_env = update_env

--- a/scif/main/environment.py
+++ b/scif/main/environment.py
@@ -150,41 +150,9 @@ def load_env(self, app):
                 for line in lines:
                     (key, _, val) = line.strip().partition("=")
                     if val not in ['', None]: # skips export lines
-                        updates[key] = self.expand_env(val)
-                        self.environment[key] = self.expand_env(val)
+                        updates[key] = val
+                        self.environment[key] = val
     return updates
-
-
-def expand_env(self, val):
-    '''expand environment will take a value, determine if there is another
-       environment variable defined, and attempt to expand it. The variable
-       can be of the format ${VAR} or $VAR.
-
-       Parameters
-       ==========
-       val: should be the value of the environment variable where other 
-            variables might be found.
-    '''
-
-    # If there is a variable defined, we want to export the actual
-    regexp = re.compile('|'.join(list(self.environment.keys())))
-    match = regexp.search(val)
-
-    while match is not None:
-
-        # Environment name
-        varname = match.group(0)
-
-        # Value it's referencing
-        referenced = self.environment[varname]
-        
-        # Handle both versions of the variable
-        val = val.replace('${%s}' %varname, referenced)
-        val = val.replace('$%s' %varname, referenced)
-
-        match = regexp.search(val)
-
-    return val
 
 
 def export_env(self, ps1=True):

--- a/scif/version.py
+++ b/scif/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.68"
+__version__ = "0.0.69"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'scif'


### PR DESCRIPTION
This will add the environment definition to be sourced at the start of the runscript, meaning that variables are defined and then run there (so if we have a situation where a variable is defined it will be properly sourced, eg.)

```
%appenv foo
   VARIABLE1=$VARIABLE2
    export VARIABLE2
```
In the case of having the python read this text and then set in the environment, we would have a hard time parsing what `VARIABLE2` is We also want to be able to handle the user passing in custom variables at runtime, so instead we add these lines to the top of the runscript (during runtime), eg given this runscript

```
%apprun foo
   echo "HELLO!"
   echo $VARIABLE1
```

The final script would be:

```
   VARIABLE1=$VARIABLE2
   export VARIABLE2
   echo "HELLO!"
   echo $VARIABLE1
```
This seems like a reasonable solution for now - the others I considered are attempting substitution (imperfect) or just adding a line to source at the top of the runscript (the equivalent of the above, but if we can add the content directly, we should do that!)