### PR TITLE
Fix/client bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ represented by the pull requests that fixed them.
  - renamed commands
  - deprecated / removed commands
  - changed defaults
- - backward incompatible changes (recipe file format? image file format?)
- - migration guidance (how to convert images?)
- - changed behaviour (recipe sections work differently)
+ - backward incompatible changes
+ - changed behaviour
 
 Versions in parentheses coincide with what is available on [pypi](https://pypi.org/project/scif/).
 
 ## [xxx](https://github.com/vsoch/scif/tree/master) (master)
+ - args not passed correctly for run and exec (0.0.77)
  - test and runscript need to be executable after write (0.0.76)
  - fixing bug that None can go into function to test app (0.0.75)
  - adding test to client, along with tests for functions (and on CircleCI) (0.0.74)

--- a/Dockerfile.hello-world
+++ b/Dockerfile.hello-world
@@ -1,10 +1,8 @@
-#######################################
-# SciF Base
+# SciF Example
 #
-# docker build -t vanessa/scif .
-# docker run vanessa/scif
-#
-#######################################
+# docker build -f Dockerfile.hello-world -t vanessa/scif:hw .
+# docker run vanessa/scif:hw
+# docker push vanessa/scif:hw
 
 FROM continuumio/miniconda3
 

--- a/docs/hello-world.scif
+++ b/docs/hello-world.scif
@@ -11,6 +11,8 @@
     export THEBESTAPP
 %apprun hello-world-script
     /bin/bash hello-world.sh
+%apprun hello-world-custom
+    echo "Hello $@"
 %appenv hello-world-env
     OMG=TACOS
 %apphelp hello-world-script

--- a/scif/__init__.py
+++ b/scif/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/__init__.py
+++ b/scif/client/__init__.py
@@ -2,7 +2,7 @@
 
 '''
 
-Copyright (C) 2016-2018 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/dump.py
+++ b/scif/client/dump.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/execute.py
+++ b/scif/client/execute.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -27,13 +27,17 @@ import os
 def main(args,parser,subparser):
 
     from scif.main import ScifRecipe
-    cmd = args.cmd
+    args = args.cmd
 
-    if len(cmd) < 2:
+    if len(args) < 2:
         bot.warning('You must supply an appname and command to execute.')
         bot.custom(prefix="Example: ", message="scif exec app echo $SCIF_APPNAME")
         sys.exit(1)
 
-    app = cmd.pop(0)
+    app = args.pop(0)
+
+    # The next must be the program to execute
+    command = args.pop(0)
+
     client = ScifRecipe(quiet=True, writable=args.writable)
-    client.execute(app, cmd)
+    client.execute(app=app, cmd=command, args=args)

--- a/scif/client/execute.py
+++ b/scif/client/execute.py
@@ -27,17 +27,17 @@ import os
 def main(args,parser,subparser):
 
     from scif.main import ScifRecipe
-    args = args.cmd
+    cmd = args.cmd
 
-    if len(args) < 2:
+    if len(cmd) < 2:
         bot.warning('You must supply an appname and command to execute.')
         bot.custom(prefix="Example: ", message="scif exec app echo $SCIF_APPNAME")
         sys.exit(1)
 
-    app = args.pop(0)
+    app = cmd.pop(0)
 
     # The next must be the program to execute
-    command = args.pop(0)
+    command = cmd.pop(0)
 
     client = ScifRecipe(quiet=True, writable=args.writable)
-    client.execute(app=app, cmd=command, args=args)
+    client.execute(app=app, cmd=command, args=cmd)

--- a/scif/client/help.py
+++ b/scif/client/help.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/inspect.py
+++ b/scif/client/inspect.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/install.py
+++ b/scif/client/install.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/install.py
+++ b/scif/client/install.py
@@ -41,7 +41,7 @@ def main(args,parser,subparser):
     if len(apps) == 0:
         apps = None
 
-    client = ScifRecipe(recipe) # writable is True
+    client = ScifRecipe(path=recipe) # writable is True
 
     # Preview the entire recipe, or the apps chosen
     client.install(apps)

--- a/scif/client/list.py
+++ b/scif/client/list.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/preview.py
+++ b/scif/client/preview.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/pyshell.py
+++ b/scif/client/pyshell.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2018 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/run.py
+++ b/scif/client/run.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2017 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/run.py
+++ b/scif/client/run.py
@@ -26,7 +26,6 @@ def main(args,parser,subparser):
 
     from scif.main import ScifRecipe
     cmd = args.cmd
-    client = ScifRecipe(quiet=True, writable=args.writable)
 
     if len(cmd) == 0:
         bot.warning('You must supply an appname to run.')

--- a/scif/client/shell.py
+++ b/scif/client/shell.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/test.py
+++ b/scif/client/test.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2017 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/client/utils.py
+++ b/scif/client/utils.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/defaults.py
+++ b/scif/defaults.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -38,13 +38,14 @@ def convert2boolean(arg):
 
 
 def getenv(variable_key, default=None, required=False, silent=True):
-    '''
-    getenv will attempt to get an environment variable. If the variable
-    is not found, None is returned.
+    ''' getenv will attempt to get an environment variable. If the variable
+        is not found, None is returned.
 
-    :param variable_key: the variable name
-    :param required: exit with error if not found
-    :param silent: Do not print debugging information for variable
+        Paramters
+        =========
+        variable_key: the variable name
+        required: exit with error if not found
+        silent: Do not print debugging information for variable
     '''
     variable = os.environ.get(variable_key, default)
     if variable is None and required:

--- a/scif/logger/message.py
+++ b/scif/logger/message.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -235,6 +235,10 @@ class SCIFMessage:
 
     def error(self, message):
         self.emit(ERROR, message, 'ERROR')
+
+    def exit(self, message, error_code=255):
+        self.emit(ERROR, message, 'ERROR')
+        sys.exit(error_code)
 
     def warning(self, message):
         self.emit(WARNING, message, 'WARNING')

--- a/scif/main/__init__.py
+++ b/scif/main/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/main/apps.py
+++ b/scif/main/apps.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -71,11 +71,12 @@ def activate(self, app, cmd=None, args=None):
         self.append_path('LD_LIBRARY_PATH', config['SCIF_APPLIB'])
 
         # Set the runscript, first to cmd provided (exec) then runscript
-        if cmd is not None:
+        if cmd != None:
             self._entry_point = parse_entrypoint(cmd)
-        
-        # Set the default entrypoint
-        self._set_entrypoint(app, 'SCIF_APPRUN', args)
+            self._entry_point += parse_entrypoint(args)
+        else:
+            # Set the default entrypoint
+            self._set_entrypoint(app, 'SCIF_APPRUN', args)
 
         # Update the environment for active app (updates ScifRecipe object)
         appenv = self.get_appenv(app, isolated=False, update=True)

--- a/scif/main/base.py
+++ b/scif/main/base.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/main/base.py
+++ b/scif/main/base.py
@@ -91,13 +91,13 @@ class ScifRecipe:
     def load(self, path, app=None, quiet=False):
         '''load a scif recipe into the object
 
-        Parameters
-        ==========
-        path: the complete path to the config (recipe file) to load, or 
-              root path of filesystem (that from calling function defaults to
-              /scif)
-        app:  if running with context of an active app, this will load the
-              active app environment for it as well.
+            Parameters
+            ==========
+            path: the complete path to the config (recipe file) to load, or 
+                  root path of filesystem (that from calling function defaults to
+                  /scif)
+            app:  if running with context of an active app, this will load the
+                  active app environment for it as well.
         '''
         # 1. path is a recipe
         if os.path.isfile(path):

--- a/scif/main/commands.py
+++ b/scif/main/commands.py
@@ -170,7 +170,7 @@ def run(self, app=None, args=None):
     # Cut out early if the app doesn't have a runscript
     config = self.app(app)
     if 'apprun' not in config:
-        bot.exit('%s does not have a runscript.' % app)
+        bot.exit('%s does not have a runscript.' % app, 0)
 
     self.activate(app, args=args)    # checks for existence
                                      # sets _active to app's name

--- a/scif/main/commands.py
+++ b/scif/main/commands.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -100,7 +100,7 @@ def _exec(self, app=None, interactive=False, exit=False):
                 print(line.rstrip().encode(loc))
 
 
-def execute(self, app, cmd=None):
+def execute(self, app, cmd=None, args=None):
     '''execute a command in the context of an app. This means the following:
 
     1. Check that the app is valid for the client. Don't proceed otherwise
@@ -113,7 +113,7 @@ def execute(self, app, cmd=None):
     app: the name of the scif app to execute a command to
 
     '''
-    self.activate(app, cmd)
+    self.activate(app, cmd, args)
                           # checks for existence
                           # sets _active to app's name
                           # updates environment

--- a/scif/main/commands.py
+++ b/scif/main/commands.py
@@ -170,7 +170,7 @@ def run(self, app=None, args=None):
     # Cut out early if the app doesn't have a runscript
     config = self.app(app)
     if 'apprun' not in config:
-        bot.exit('%s does not have a runscript.' % app, 0)
+        bot.exit('%s does not have a runscript.' % app)
 
     self.activate(app, args=args)    # checks for existence
                                      # sets _active to app's name

--- a/scif/main/commands.py
+++ b/scif/main/commands.py
@@ -167,6 +167,11 @@ def run(self, app=None, args=None):
     args: a list of one or more additional arguments to pass to runscript
 
     '''
+    # Cut out early if the app doesn't have a runscript
+    config = self.app(app)
+    if 'apprun' not in config:
+        bot.exit('%s does not have a runscript.' % app)
+
     self.activate(app, args=args)    # checks for existence
                                      # sets _active to app's name
                                      # updates environment

--- a/scif/main/environment.py
+++ b/scif/main/environment.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -69,18 +69,18 @@ def get_append_path(self, key, value, environ=None):
 
 
 def init_env(self, config, base='/scif', active=None):
-    '''env will parse the complete SCIF namespace environment from a config.
-    this will be defined for all apps to allow for easy interaction between
-    them, regardless of which individual app is active.
+    ''' env will parse the complete SCIF namespace environment from a config.
+        this will be defined for all apps to allow for easy interaction between
+        them, regardless of which individual app is active.
     
-    Parameters
-    ==========
-    config: the config loaded in with "load" in this file.
-    active: the name of the active app, if relevant.
+        Parameters
+        ==========
+        config: the config loaded in with "load" in this file.
+        active: the name of the active app, if relevant.
 
-    Example: the following environment variables would be defined for an app
-             called "google-drive" Note that for the variable, the slash is
-             replaced with an underscore
+        Example: the following environment variables would be defined for an app
+                 called "google-drive" Note that for the variable, the slash is
+                 replaced with an underscore
 
              SCIF_APPDATA_google_drive=/scif/data/google-drive
              SCIF_APPRUN_google_drive=/scif/apps/google-drive/scif/runscript
@@ -121,11 +121,11 @@ def init_env(self, config, base='/scif', active=None):
 
 
 def update_env(self, reset=False):
-    '''If the SCIF is loaded, upload the object's environment.
+    ''' If the SCIF is loaded, upload the object's environment.
 
-    Parameters
-    ==========
-    reset: if True, empty the environment before parsing from config
+        Parameters
+        ==========
+        reset: if True, empty the environment before parsing from config
 
     '''
 
@@ -349,14 +349,14 @@ def get_appenv_lookup(self, app):
 # ScifRecipe Environment Helpers
 
 def add_env(self, key, value):
-    '''add a key/value pair to the environment. Should begin with SCIF
-       to maintain proper namespace
+    ''' add a key/value pair to the environment. Should begin with SCIF
+        to maintain proper namespace
 
-    Parameters
-    ==========
-    key: the environment variable name. For SCIF, slashes should be 
-         removed and replaced with underscore.
-    value: the value to set for the environment variable
+        Parameters
+        ==========
+        key: the environment variable name. For SCIF, slashes should be 
+             removed and replaced with underscore.
+        value: the value to set for the environment variable
 
     '''    
     if not hasattr(self,'environment'):

--- a/scif/main/helpers.py
+++ b/scif/main/helpers.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -105,7 +105,8 @@ def set_entrypoint(self, app, config_key='SCIF_APPRUN', args=None):
 
 def parse_entrypoint(entry_point=None):
     '''parse entrypoint will return a list, where the first argument is the
-       executable, followed by arguments
+       executable, followed by arguments. This function also works to
+       parse arguments into a list.
  
        Parameters
        ==========

--- a/scif/main/install.py
+++ b/scif/main/install.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/main/parser.py
+++ b/scif/main/parser.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -28,13 +28,13 @@ import sys
 def load_filesystem(base, quiet=False):
     '''load a filesystem based on a root path, which is usually /scif
 
-    Parameters
-    ==========
-    base: base to load.
+        Parameters
+        ==========
+        base: base to load.
 
-    Returns
-    =======
-    config: a parsed recipe configuration for SCIF
+        Returns
+        =======
+        config: a parsed recipe configuration for SCIF
     '''
     from scif.defaults import SCIF_APPS
 
@@ -57,13 +57,13 @@ def load_filesystem(base, quiet=False):
 def load_recipe(path):
     '''load will return a loaded in (user) scif configuration file
 
-    Parameters
-    ==========
-    path: a path to a scif recipe file
+        Parameters
+        ==========
+        path: a path to a scif recipe file
 
-    Returns
-    =======
-    config: a parsed recipe configuration for SCIF
+        Returns
+        =======
+        config: a parsed recipe configuration for SCIF
     '''
 
     path = os.path.abspath(path)
@@ -200,16 +200,16 @@ def read_section(config, spec, section, name, global_section='apps'):
 
 
 def add_section(config, section, name=None, global_section="apps"):
-    '''add section will add a section (and optionally)
-    section name to a config
+    ''' add section will add a section (and optionally)
+        section name to a config
 
-    Parameters
-    ==========
-    config: the config (dict) parsed thus far
-    section: the section type (e.g., appinstall)
-    name: an optional name, added as a level (e.g., google-drive)
+        Parameters
+        ==========
+        config: the config (dict) parsed thus far
+        section: the section type (e.g., appinstall)
+        name: an optional name, added as a level (e.g., google-drive)
 
-    Resulting data structure is:
+        Resulting data structure is:
 
             config['registry']['apprun']
             config[name][section]

--- a/scif/main/parser.py
+++ b/scif/main/parser.py
@@ -158,10 +158,6 @@ def finish_recipe(config, global_section='apps'):
             if "apprun" in config[global_section][app]:
                 apprun = config[global_section][app]['apprun']
                 config[global_section][app]['apprun'] =  appenv + apprun
-            else:    
-                # An app can just be an environment
-                config[global_section][app]['apprun'] = appenv
-
 
     return config
 

--- a/scif/main/preview.py
+++ b/scif/main/preview.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/main/setup.py
+++ b/scif/main/setup.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/scif/tests/test_run.sh
+++ b/scif/tests/test_run.sh
@@ -5,4 +5,5 @@ CONTAINER_NAME=${1:-}
 echo "Testing run of each app:"
 docker run -it "${CONTAINER_NAME}" run hello-world-echo
 docker run -it "${CONTAINER_NAME}" run hello-world-script
-docker run -it "${CONTAINER_NAME}" run hello-world-env
+docker run -it "${CONTAINER_NAME}" run hello-world-custom "Meatball"
+docker run -it "${CONTAINER_NAME}" run hello-world-env | echo "Success"

--- a/scif/utils/fileio.py
+++ b/scif/utils/fileio.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -92,7 +92,7 @@ def copyfile(source, destination, force=True):
 
 def write_file(filename, content, mode="w"):
     '''write_file will open a file, "filename" and write content, "content"
-    and properly close the file
+        and properly close the file
     '''
     with codecs.open(filename, mode, encoding='utf-8') as filey:
         filey.writelines(content)
@@ -101,9 +101,12 @@ def write_file(filename, content, mode="w"):
 
 def write_json(json_obj, filename, mode="w", print_pretty=True):
     '''write_json will (optionally,pretty print) a json object to file
-    :param json_obj: the dict to print to json
-    :param filename: the output file to write to
-    :param pretty_print: if True, will use nicer formatting
+
+       Parameters
+       ==========
+       json_obj: the dict to print to json
+       filename: the output file to write to
+       pretty_print: if True, will use nicer formatting
     '''
     with codecs.open(filename, mode, encoding='utf-8') as filey:
         if print_pretty:
@@ -122,7 +125,7 @@ def write_json(json_obj, filename, mode="w", print_pretty=True):
 
 def read_file(filename, mode="r", readlines=True):
     '''write_file will open a file, "filename" and write content, "content"
-    and properly close the file
+       and properly close the file
     '''
     with codecs.open(filename, mode, encoding='utf-8') as filey:
         if readlines is True:
@@ -134,7 +137,7 @@ def read_file(filename, mode="r", readlines=True):
 
 def read_json(filename, mode='r'):
     '''read_json reads in a json file and returns
-    the data structure as dict.
+       the data structure as dict.
     '''
     with codecs.open(filename, mode, encoding='utf-8') as filey:
         data = json.load(filey)

--- a/scif/utils/terminal.py
+++ b/scif/utils/terminal.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -40,10 +40,13 @@ def get_installdir():
 
 def run_command(cmd, sudo=False):
     '''run_command uses subprocess to send a command to the terminal.
-    :param cmd: the command to send, should be a list for subprocess
-    :param error_message: the error message to give to user if fails,
-    if none specified, will alert that command failed.
-    :param sudopw: if specified (not None) command will be run asking for sudo
+
+       Parameters
+       ==========
+       cmd: the command to send, should be a list for subprocess
+       error_message: the error message to give to user if fails,
+                      if none specified, will alert that command failed.
+       sudo: if True (default False) command will be run asking for sudo
     '''
     if not isinstance(cmd, list):
         cmd = shlex.split(cmd)

--- a/scif/version.py
+++ b/scif/version.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.76"
+__version__ = "0.0.77"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'scif'


### PR DESCRIPTION
This will fix two client bugs:

 1. arguments aren't correctly passed with run.

I've pushed the container `vanessa/scif:hw` to test this fix, here is an example of arguments being passed correctly:

```bash
$ docker run -it vanessa/scif:hw run hello-world-custom THINGONE
[hello-world-custom] executing /bin/bash /scif/apps/hello-world-custom/scif/runscript THINGONE
Hello THINGONE

$ docker run -it vanessa/scif:hw run hello-world-custom THINGONE THINGTWO
[hello-world-custom] executing /bin/bash /scif/apps/hello-world-custom/scif/runscript THINGONE THINGTWO
Hello THINGONE THINGTWO

$ docker run -it vanessa/scif:hw run hello-world-custom THINGONE THINGTWO --omg
[hello-world-custom] executing /bin/bash /scif/apps/hello-world-custom/scif/runscript THINGONE THINGTWO --omg
Hello THINGONE THINGTWO --omg
```

 2. The next issue is that exec was hitting the runscript (instead of executing the command). Here is the fixed example:

```bash
$ docker run vanessa/scif:hw exec hello-world-env echo "Meatballs"
[hello-world-env] executing /bin/echo Meatballs
Meatballs
```
In addition, I've updated the date in the headers.

This will close #54 #53 