### PR TITLE
fix shell behavior

### DIFF
--- a/scif/main/apps.py
+++ b/scif/main/apps.py
@@ -73,7 +73,8 @@ def activate(self, app, cmd=None, args=None):
         # Set the runscript, first to cmd provided (exec) then runscript
         if cmd != None:
             self._entry_point = parse_entrypoint(cmd)
-            self._entry_point += parse_entrypoint(args)
+            if args is not None:
+                self._entry_point += parse_entrypoint(args)
         else:
             # Set the default entrypoint
             self._set_entrypoint(app, 'SCIF_APPRUN', args)

--- a/scif/main/commands.py
+++ b/scif/main/commands.py
@@ -171,13 +171,11 @@ def run(self, app=None, args=None):
     args: a list of one or more additional arguments to pass to runscript
 
     '''
-    # Cut out early if the app doesn't have a runscript
+    interactive = False
     config = self.app(app)
     if 'apprun' not in config:
         bot.debug('%s does not have a runscript.' % app)
         interactive = True
-    else:
-        interactive = False
 
     self.activate(app, args=args)    # checks for existence
                                      # sets _active to app's name

--- a/scif/main/commands.py
+++ b/scif/main/commands.py
@@ -174,7 +174,10 @@ def run(self, app=None, args=None):
     # Cut out early if the app doesn't have a runscript
     config = self.app(app)
     if 'apprun' not in config:
-        bot.exit('%s does not have a runscript.' % app)
+        bot.debug('%s does not have a runscript.' % app)
+        interactive = True
+    else:
+        interactive = False
 
     self.activate(app, args=args)    # checks for existence
                                      # sets _active to app's name
@@ -182,7 +185,7 @@ def run(self, app=None, args=None):
                                      # sets entrypoint
                                      # sets entryfolder
 
-    return self._exec(app)
+    return self._exec(app, interactive=interactive)
 
 
 def test(self, app=None, args=None):


### PR DESCRIPTION
This PR fixes 2 shell related issues.

First, an extra `/bin/bash` gets appended to the `shell` entrypoint:

```
$ scif shell ref
[ref] executing /bin/bash /bin/bash
/bin/bash: /bin/bash: cannot execute binary file
```

This is fixed by checking whether `args` is defined in `activate()`.

Second, the [documentation](https://sci-f.github.io/tutorial-commands) says `If an app doesn’t have an %apprun section, we default to a shell.`  However, this case is treated as an error:

```
$ scif run ref 
ERROR ref does not have a runscript.
```

This is fixed by converting this message from an error to a debug statement.  Also correctly sets the resulting shell as interactive.