### PR TITLE
Only support Python 3.6 and up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ represented by the pull requests that fixed them.
 Versions in parentheses coincide with what is available on [pypi](https://pypi.org/project/scif/).
 
 ## [xxx](https://github.com/vsoch/scif/tree/master) (master)
+ - removing Python less than 3.6 support (0.0.80)
  - code formatting with black, shell entrypoint bug (0.0.79)
  - executable not found, will not run, adding streaming to output (0.0.78)
  - args not passed correctly for run and exec (0.0.77)

--- a/scif/utils/terminal.py
+++ b/scif/utils/terminal.py
@@ -44,12 +44,19 @@ def run_command(cmd, sudo=False, quiet=False):
     if sudo is True:
         cmd = ["sudo"] + cmd
 
-    process = Popen(cmd, stderr=STDOUT, stdout=PIPE, encoding="utf8")
+    process = Popen(cmd, stderr=STDOUT, stdout=PIPE)
 
     # Iterate through the output
     result = ""
     while True:
         output = process.stdout.readline()
+
+        # Encode output to utf-8, if appropriate
+        try:
+            output = output.decode("utf-8")
+        except:
+            pass
+
         if output == "" and process.poll() is not None:
             break
         if output:

--- a/scif/version.py
+++ b/scif/version.py
@@ -10,7 +10,7 @@ Modified from https://github.com/Visual-mov/Colorful-Julia (MIT License)
 
 """
 
-__version__ = "0.0.79"
+__version__ = "0.0.80"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "scif"

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
             "Topic :: Software Development",
             "Topic :: Scientific/Engineering",
             "Operating System :: Unix",
-            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3",
         ],
         entry_points={"console_scripts": ["scif=scif.client:main"]},
     )

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ if __name__ == "__main__":
         license=LICENSE,
         description=DESCRIPTION,
         long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/markdown",
         keywords=KEYWORDS,
         install_requires=INSTALL_REQUIRES,
         test_suite="nose.collector",
@@ -97,8 +98,7 @@ if __name__ == "__main__":
             "Topic :: Software Development",
             "Topic :: Scientific/Engineering",
             "Operating System :: Unix",
-            "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.6",
         ],
         entry_points={"console_scripts": ["scif=scif.client:main"]},
     )


### PR DESCRIPTION
This is a work in progress to discuss changes to Python version support. Obviously 2.x is not supported, so we are discussing in #63 about how to handle Python 3.x.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>