### PR TITLE
install script should exit on nonzero return code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ represented by the pull requests that fixed them.
 Versions in parentheses coincide with what is available on [pypi](https://pypi.org/project/scif/).
 
 ## [xxx](https://github.com/vsoch/scif/tree/master) (master)
+ - install return value non zero should stop build (0.0.81)
  - removing Python less than 3.6 support (0.0.80)
  - code formatting with black, shell entrypoint bug (0.0.79)
  - executable not found, will not run, adding streaming to output (0.0.78)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.md LICENSE
 recursive-include scif *
 recursive-include scif/tests *.sh
 global-exclude *.py[co]
+prune docs
 global-exclude *.img
 global-exclude OLD-scif/*
 global-exclude *.simg

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,7 @@
+# Examples
+
+This is a small folder of examples intended to be built to test or otherwise
+show how something works. If you would like an example added, please 
+[open an issue](https://github.com/vsoch/scif).
+
+ - [Exit on Install](exit-on-install): A container to test exit on install error (non zero return value).

--- a/docs/examples/exit-on-install/Dockerfile
+++ b/docs/examples/exit-on-install/Dockerfile
@@ -1,6 +1,6 @@
 # SciF Example
 #
-# docker build -f Dockerfile.exit-nonzer -t scif-exit .
+# docker build -f docs/examples/exit-on-install/Dockerfile -t scif-exit .
 
 FROM continuumio/miniconda3
 

--- a/docs/examples/exit-on-install/Dockerfile
+++ b/docs/examples/exit-on-install/Dockerfile
@@ -1,0 +1,22 @@
+# SciF Example
+#
+# docker build -f Dockerfile.exit-nonzer -t scif-exit .
+
+FROM continuumio/miniconda3
+
+#######################################
+# SciF Install
+#######################################
+
+# Can be replaced with pip install scif
+RUN mkdir /code
+ADD . /code
+RUN python /code/setup.py install
+ENV PATH=/opt/conda/bin:$PATH
+
+#######################################
+# SciF Entrypoint
+#######################################
+
+RUN scif install /code/docs/examples/exit-on-install/recipe.scif
+ENTRYPOINT ["scif"]

--- a/docs/examples/exit-on-install/README.md
+++ b/docs/examples/exit-on-install/README.md
@@ -1,0 +1,36 @@
+# Exit on Install
+
+This should be built from the root of the repository as follows:
+
+```bash
+docker build -f docs/examples/exit-on-install/Dockerfile -t scif-exit-on-install .
+```
+
+When you build the above, it should exit on the install of one of the apps:
+
+```bash
+Using /opt/conda/lib/python3.7/site-packages
+Finished processing dependencies for scif==0.0.81
+Removing intermediate container adef9b9e2880
+ ---> 1827c8e9dfde
+Step 5/7 : ENV PATH=/opt/conda/bin:$PATH
+ ---> Running in 02f699d02f52
+Removing intermediate container 02f699d02f52
+ ---> 6916a222e1c6
+Step 6/7 : RUN scif install /code/docs/examples/exit-on-install/recipe.scif
+ ---> Running in 30639ab520f0
+ERROR Return value 256 for install of hello-world-script
+Installing base at /scif
++ apprun     hello-world-echo
++ appenv     hello-world-echo
++ apprun     hello-world-script
++ appenv     hello-world-script
++ apphelp     hello-world-script
++ appinstall hello-world-script
+The command '/bin/sh -c scif install /code/docs/examples/exit-on-install/recipe.scif' returned a non-zero code: 1
+```
+The user is alerted of the error here:
+
+```bash
+ERROR Return value 256 for install of hello-world-script
+```

--- a/docs/examples/exit-on-install/recipe.scif
+++ b/docs/examples/exit-on-install/recipe.scif
@@ -1,0 +1,42 @@
+%appenv hello-world-echo
+    THEBESTAPP=hello-world-echo
+    export THEBESTAPP
+%apprun hello-world-echo
+    echo "The best app is $THEBESTAPP"
+%appinstall hello-world-script
+    echo "echo 'Hello World!'" >> $SCIF_APPBIN/hello-world.sh
+    chmod u+x $SCIF_APPBIN/hello-world.sh
+    return 1
+%appenv hello-world-script
+    THEBESTAPP=$SCIF_APPNAME
+    export THEBESTAPP
+%apprun hello-world-script
+    /bin/bash hello-world.sh
+%apprun hello-world-custom
+    echo "Hello $@"
+%appenv hello-world-env
+    OMG=TACOS
+%apphelp hello-world-script
+   This version of hello world runs a script to print hello world
+%apphelp hello-world-env
+   This is the help section for hello-world-env! This app
+   does not have anything other than an environment installed. 
+   It just defines the environment variable `OMG=TACOS`. Try issuing
+   a command to the scif entrypoint to echo this variable:
+
+        # Local installation
+        scif exec hello-world-env echo [e]OMG
+        
+        # Docker image example
+        docker run quay.io/scif/scif exec hello-world-env echo [e]OMG
+        [hello-world-env] executing /bin/echo $OMG
+        TACOS
+%apptest hello-world-script
+    echo "Running tests!"
+    if [ $# -eq 0 ]
+        then
+            echo "No arguments supplied, tests pass!"
+            exit 0
+        fi
+    echo "Argument supplied, exiting with ${1}"
+    exit ${1}

--- a/scif/main/install.py
+++ b/scif/main/install.py
@@ -158,7 +158,9 @@ def install_commands(self, app, settings, config):
         # issue install commands
         cmd = "\n".join(config["appinstall"])
         bot.info("+ " + "appinstall ".ljust(5) + app)
-        os.system(cmd)
+        retval = os.system(cmd)
+        if retval != 0:
+            bot.exit("Return value %s for install of %s" % (retval, app))
 
         # Go back to previous location
         os.chdir(pwd)

--- a/scif/main/install.py
+++ b/scif/main/install.py
@@ -155,8 +155,11 @@ def install_commands(self, app, settings, config):
         pwd = os.getcwd()
         os.chdir(settings["approot"])
 
+        # Set strict mode to ensure exit on error
+        command = ["set -e"] + config["appinstall"]
+
         # issue install commands
-        cmd = "\n".join(config["appinstall"])
+        cmd = "\n".join(command)
         bot.info("+ " + "appinstall ".ljust(5) + app)
         retval = os.system(cmd)
         if retval != 0:

--- a/scif/version.py
+++ b/scif/version.py
@@ -10,7 +10,7 @@ Modified from https://github.com/Visual-mov/Colorful-Julia (MIT License)
 
 """
 
-__version__ = "0.0.80"
+__version__ = "0.0.81"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "scif"


### PR DESCRIPTION
This pull request will address #65, specifically, a non zero return value when commands are being issued to install should exit appropriately. I've provided an example container and recipe to show the addition working.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>